### PR TITLE
feat(template): Add base path api parameter

### DIFF
--- a/src/opex_dashboard/templates/api-management_queries/availability.kusto
+++ b/src/opex_dashboard/templates/api-management_queries/availability.kusto
@@ -1,7 +1,7 @@
-{% load stringify uri_to_regex %}
+{% load add_str stringify uri_to_regex %}
 let threshold = {{ threshold|default:"0.99" }};
 AzureDiagnostics
-| where url_s matches regex "{{ base_path|default:""|add:endpoint|uri_to_regex }}"
+| where url_s matches regex "{{ base_path|default:""|add_str:endpoint|uri_to_regex }}"
 | summarize
   Total=count(),
   Success=count(responseCode_d < 500) by bin(TimeGenerated, {{ timespan }})

--- a/src/opex_dashboard/templates/api-management_queries/availability.kusto
+++ b/src/opex_dashboard/templates/api-management_queries/availability.kusto
@@ -1,7 +1,7 @@
 {% load stringify uri_to_regex %}
 let threshold = {{ threshold|default:"0.99" }};
 AzureDiagnostics
-| where url_s matches regex "{{ endpoint|uri_to_regex }}"
+| where url_s matches regex "{{ base_path|default:""|add:endpoint|uri_to_regex }}"
 | summarize
   Total=count(),
   Success=count(responseCode_d < 500) by bin(TimeGenerated, {{ timespan }})

--- a/src/opex_dashboard/templates/api-management_queries/response_codes.kusto
+++ b/src/opex_dashboard/templates/api-management_queries/response_codes.kusto
@@ -1,5 +1,5 @@
 {% load stringify uri_to_regex %}
-let api_url = "{{ endpoint|uri_to_regex }}";
+let api_url = "{{ base_path|default:""|add:endpoint|uri_to_regex }}";
 AzureDiagnostics
 | where url_s matches regex api_url
 | extend HTTPStatus = case(

--- a/src/opex_dashboard/templates/api-management_queries/response_codes.kusto
+++ b/src/opex_dashboard/templates/api-management_queries/response_codes.kusto
@@ -1,5 +1,5 @@
-{% load stringify uri_to_regex %}
-let api_url = "{{ base_path|default:""|add:endpoint|uri_to_regex }}";
+{% load add_str stringify uri_to_regex %}
+let api_url = "{{ base_path|default:""|add_str:endpoint|uri_to_regex }}";
 AzureDiagnostics
 | where url_s matches regex api_url
 | extend HTTPStatus = case(

--- a/src/opex_dashboard/templates/api-management_queries/response_time.kusto
+++ b/src/opex_dashboard/templates/api-management_queries/response_time.kusto
@@ -1,7 +1,7 @@
 {% load stringify uri_to_regex %}
 let threshold = {{ threshold|default:"1" }};
 AzureDiagnostics
-| where url_s matches regex "{{ endpoint|uri_to_regex }}"
+| where url_s matches regex "{{ base_path|default:""|add:endpoint|uri_to_regex }}"
 | summarize
     watermark=threshold,
     duration_percentile_95=percentiles(todouble(DurationMs)/1000, 95) by bin(TimeGenerated, {{ timespan }})

--- a/src/opex_dashboard/templates/api-management_queries/response_time.kusto
+++ b/src/opex_dashboard/templates/api-management_queries/response_time.kusto
@@ -1,7 +1,7 @@
-{% load stringify uri_to_regex %}
+{% load add_str stringify uri_to_regex %}
 let threshold = {{ threshold|default:"1" }};
 AzureDiagnostics
-| where url_s matches regex "{{ base_path|default:""|add:endpoint|uri_to_regex }}"
+| where url_s matches regex "{{ base_path|default:""|add_str:endpoint|uri_to_regex }}"
 | summarize
     watermark=threshold,
     duration_percentile_95=percentiles(todouble(DurationMs)/1000, 95) by bin(TimeGenerated, {{ timespan }})

--- a/src/opex_dashboard/templates/app-gateway_queries/availability.kusto
+++ b/src/opex_dashboard/templates/app-gateway_queries/availability.kusto
@@ -1,9 +1,9 @@
-{% load stringify uri_to_regex %}
+{% load add_str stringify uri_to_regex %}
 let api_hosts = datatable (name: string) {{ hosts|stringify }};
 let threshold = {{ threshold|default:"0.99" }};
 AzureDiagnostics
 | where originalHost_s in (api_hosts)
-| where requestUri_s matches regex "{{ base_path|default:""|add:endpoint|uri_to_regex }}"
+| where requestUri_s matches regex "{{ base_path|default:""|add_str:endpoint|uri_to_regex }}"
 | summarize
   Total=count(),
   Success=count(httpStatus_d < 500) by bin(TimeGenerated, {{ timespan }})

--- a/src/opex_dashboard/templates/app-gateway_queries/availability.kusto
+++ b/src/opex_dashboard/templates/app-gateway_queries/availability.kusto
@@ -3,7 +3,7 @@ let api_hosts = datatable (name: string) {{ hosts|stringify }};
 let threshold = {{ threshold|default:"0.99" }};
 AzureDiagnostics
 | where originalHost_s in (api_hosts)
-| where requestUri_s matches regex "{{ endpoint|uri_to_regex }}"
+| where requestUri_s matches regex "{{ base_path|default:""|add:endpoint|uri_to_regex }}"
 | summarize
   Total=count(),
   Success=count(httpStatus_d < 500) by bin(TimeGenerated, {{ timespan }})

--- a/src/opex_dashboard/templates/app-gateway_queries/response_codes.kusto
+++ b/src/opex_dashboard/templates/app-gateway_queries/response_codes.kusto
@@ -1,5 +1,5 @@
 {% load stringify uri_to_regex %}
-let api_url = "{{ endpoint|uri_to_regex }}";
+let api_url = "{{ base_path|default:""|add:endpoint|uri_to_regex }}";
 let api_hosts = datatable (name: string) {{ hosts|stringify }};
 AzureDiagnostics
 | where originalHost_s in (api_hosts)

--- a/src/opex_dashboard/templates/app-gateway_queries/response_codes.kusto
+++ b/src/opex_dashboard/templates/app-gateway_queries/response_codes.kusto
@@ -1,5 +1,5 @@
-{% load stringify uri_to_regex %}
-let api_url = "{{ base_path|default:""|add:endpoint|uri_to_regex }}";
+{% load add_str stringify uri_to_regex %}
+let api_url = "{{ base_path|default:""|add_str:endpoint|uri_to_regex }}";
 let api_hosts = datatable (name: string) {{ hosts|stringify }};
 AzureDiagnostics
 | where originalHost_s in (api_hosts)

--- a/src/opex_dashboard/templates/app-gateway_queries/response_time.kusto
+++ b/src/opex_dashboard/templates/app-gateway_queries/response_time.kusto
@@ -3,7 +3,7 @@ let api_hosts = datatable (name: string) {{ hosts|stringify }};
 let threshold = {{ threshold|default:"1" }};
 AzureDiagnostics
 | where originalHost_s in (api_hosts)
-| where requestUri_s matches regex "{{ endpoint|uri_to_regex }}"
+| where requestUri_s matches regex "{{ base_path|default:""|add:endpoint|uri_to_regex }}"
 | summarize
     watermark=threshold,
     duration_percentile_95=percentiles(timeTaken_d, 95) by bin(TimeGenerated, {{ timespan }})

--- a/src/opex_dashboard/templates/app-gateway_queries/response_time.kusto
+++ b/src/opex_dashboard/templates/app-gateway_queries/response_time.kusto
@@ -1,9 +1,9 @@
-{% load stringify uri_to_regex %}
+{% load add_str stringify uri_to_regex %}
 let api_hosts = datatable (name: string) {{ hosts|stringify }};
 let threshold = {{ threshold|default:"1" }};
 AzureDiagnostics
 | where originalHost_s in (api_hosts)
-| where requestUri_s matches regex "{{ base_path|default:""|add:endpoint|uri_to_regex }}"
+| where requestUri_s matches regex "{{ base_path|default:""|add_str:endpoint|uri_to_regex }}"
 | summarize
     watermark=threshold,
     duration_percentile_95=percentiles(timeTaken_d, 95) by bin(TimeGenerated, {{ timespan }})

--- a/src/opex_dashboard/templates/azure_dashboard_raw.json
+++ b/src/opex_dashboard/templates/azure_dashboard_raw.json
@@ -79,7 +79,7 @@
                 },
                 {
                   "name": "PartSubTitle",
-                  "value": "{{ endpoint }}",
+                  "value": "{{ base_path|default:""|add:endpoint }}",
                   "isOptional": true
                 },
                 {
@@ -202,7 +202,7 @@
                 },
                 {
                   "name": "PartSubTitle",
-                  "value": "{{ endpoint }}",
+                  "value": "{{ base_path|default:""|add:endpoint }}",
                   "isOptional": true
                 },
                 {
@@ -341,7 +341,7 @@
                 },
                 {
                   "name": "PartSubTitle",
-                  "value": "{{ endpoint }}",
+                  "value": "{{ base_path|default:""|add:endpoint }}",
                   "isOptional": true
                 },
                 {

--- a/src/opex_dashboard/templates/azure_dashboard_raw.json
+++ b/src/opex_dashboard/templates/azure_dashboard_raw.json
@@ -79,7 +79,7 @@
                 },
                 {
                   "name": "PartSubTitle",
-                  "value": "{{ base_path|default:""|add:endpoint }}",
+                  "value": "{{ base_path|default:""|add_str:endpoint }}",
                   "isOptional": true
                 },
                 {
@@ -202,7 +202,7 @@
                 },
                 {
                   "name": "PartSubTitle",
-                  "value": "{{ base_path|default:""|add:endpoint }}",
+                  "value": "{{ base_path|default:""|add_str:endpoint }}",
                   "isOptional": true
                 },
                 {
@@ -341,7 +341,7 @@
                 },
                 {
                   "name": "PartSubTitle",
-                  "value": "{{ base_path|default:""|add:endpoint }}",
+                  "value": "{{ base_path|default:""|add_str:endpoint }}",
                   "isOptional": true
                 },
                 {

--- a/src/opex_dashboard/templates/azure_dashboard_terraform.tf
+++ b/src/opex_dashboard/templates/azure_dashboard_terraform.tf
@@ -22,7 +22,7 @@ resource "azurerm_portal_dashboard" "this" {
 
 {% for endpoint,props in endpoints.items %}
 resource "azurerm_monitor_scheduled_query_rules_alert" "alarm_availability_{{ forloop.counter0 }}" {
-  name                = replace(join("_",split("/", "${local.name}-availability @ {{endpoint}}")), "/\\{|\\}/", "")
+  name                = replace(join("_",split("/", "${local.name}-availability @ {{base_path|default:""|add:endpoint}}")), "/\\{|\\}/", "")
   resource_group_name = data.azurerm_resource_group.this.name
   location            = data.azurerm_resource_group.this.location
 
@@ -31,7 +31,7 @@ resource "azurerm_monitor_scheduled_query_rules_alert" "alarm_availability_{{ fo
   }
 
   data_source_id          = "{{ data_source_id }}"
-  description             = "Availability for {{endpoint}} is less than or equal to 99% - ${local.dashboard_base_addr}${azurerm_portal_dashboard.this.id}"
+  description             = "Availability for {{base_path|default:""|add:endpoint}} is less than or equal to 99% - ${local.dashboard_base_addr}${azurerm_portal_dashboard.this.id}"
   enabled                 = true
   auto_mitigation_enabled = false
 
@@ -53,7 +53,7 @@ resource "azurerm_monitor_scheduled_query_rules_alert" "alarm_availability_{{ fo
 }
 
 resource "azurerm_monitor_scheduled_query_rules_alert" "alarm_time_{{ forloop.counter0 }}" {
-  name                = replace(join("_",split("/", "${local.name}-responsetime @ {{endpoint}}")), "/\\{|\\}/", "")
+  name                = replace(join("_",split("/", "${local.name}-responsetime @ {{base_path|default:""|add:endpoint}}")), "/\\{|\\}/", "")
   resource_group_name = data.azurerm_resource_group.this.name
   location            = data.azurerm_resource_group.this.location
 
@@ -62,7 +62,7 @@ resource "azurerm_monitor_scheduled_query_rules_alert" "alarm_time_{{ forloop.co
   }
 
   data_source_id          = "{{ data_source_id }}"
-  description             = "Response time for {{endpoint}} is less than or equal to 1s - ${local.dashboard_base_addr}${azurerm_portal_dashboard.this.id}"
+  description             = "Response time for {{base_path|default:""|add:endpoint}} is less than or equal to 1s - ${local.dashboard_base_addr}${azurerm_portal_dashboard.this.id}"
   enabled                 = true
   auto_mitigation_enabled = false
 

--- a/src/opex_dashboard/templates/azure_dashboard_terraform.tf
+++ b/src/opex_dashboard/templates/azure_dashboard_terraform.tf
@@ -22,7 +22,7 @@ resource "azurerm_portal_dashboard" "this" {
 
 {% for endpoint,props in endpoints.items %}
 resource "azurerm_monitor_scheduled_query_rules_alert" "alarm_availability_{{ forloop.counter0 }}" {
-  name                = replace(join("_",split("/", "${local.name}-availability @ {{base_path|default:""|add:endpoint}}")), "/\\{|\\}/", "")
+  name                = replace(join("_",split("/", "${local.name}-availability @ {{base_path|default:""|add_str:endpoint}}")), "/\\{|\\}/", "")
   resource_group_name = data.azurerm_resource_group.this.name
   location            = data.azurerm_resource_group.this.location
 
@@ -31,7 +31,7 @@ resource "azurerm_monitor_scheduled_query_rules_alert" "alarm_availability_{{ fo
   }
 
   data_source_id          = "{{ data_source_id }}"
-  description             = "Availability for {{base_path|default:""|add:endpoint}} is less than or equal to 99% - ${local.dashboard_base_addr}${azurerm_portal_dashboard.this.id}"
+  description             = "Availability for {{base_path|default:""|add_str:endpoint}} is less than or equal to 99% - ${local.dashboard_base_addr}${azurerm_portal_dashboard.this.id}"
   enabled                 = true
   auto_mitigation_enabled = false
 
@@ -53,7 +53,7 @@ resource "azurerm_monitor_scheduled_query_rules_alert" "alarm_availability_{{ fo
 }
 
 resource "azurerm_monitor_scheduled_query_rules_alert" "alarm_time_{{ forloop.counter0 }}" {
-  name                = replace(join("_",split("/", "${local.name}-responsetime @ {{base_path|default:""|add:endpoint}}")), "/\\{|\\}/", "")
+  name                = replace(join("_",split("/", "${local.name}-responsetime @ {{base_path|default:""|add_str:endpoint}}")), "/\\{|\\}/", "")
   resource_group_name = data.azurerm_resource_group.this.name
   location            = data.azurerm_resource_group.this.location
 
@@ -62,7 +62,7 @@ resource "azurerm_monitor_scheduled_query_rules_alert" "alarm_time_{{ forloop.co
   }
 
   data_source_id          = "{{ data_source_id }}"
-  description             = "Response time for {{base_path|default:""|add:endpoint}} is less than or equal to 1s - ${local.dashboard_base_addr}${azurerm_portal_dashboard.this.id}"
+  description             = "Response time for {{base_path|default:""|add_str:endpoint}} is less than or equal to 1s - ${local.dashboard_base_addr}${azurerm_portal_dashboard.this.id}"
   enabled                 = true
   auto_mitigation_enabled = false
 

--- a/test/snapshots/iobackend_light_overrides_base_path.txt
+++ b/test/snapshots/iobackend_light_overrides_base_path.txt
@@ -1,0 +1,1027 @@
+
+locals {
+  name                = "${var.prefix}-${var.env_short}-PROD-IO/IO_App_Availability"
+  dashboard_base_addr = "https://portal.azure.com/#@pagopait.onmicrosoft.com/dashboard/arm"
+}
+
+data "azurerm_resource_group" "this" {
+  name     = "dashboards"
+}
+
+resource "azurerm_portal_dashboard" "this" {
+  name                = local.name
+  resource_group_name = data.azurerm_resource_group.this.name
+  location            = data.azurerm_resource_group.this.location
+
+  dashboard_properties = <<-PROPS
+    {
+  "lenses": {
+    "0": {
+      "order": 0,
+      "parts": {
+        "0": {
+          "position": {
+            "x": 0,
+            "y": 0,
+            "colSpan": 6,
+            "rowSpan": 4
+          },
+          "metadata": {
+            "inputs": [
+              {
+                "name": "resourceTypeMode",
+                "isOptional": true
+              },
+              {
+                "name": "ComponentId",
+                "isOptional": true
+              },
+              {
+                "name": "Scope",
+                "value": {
+                  "resourceIds": [
+                    "/subscriptions/uuid/resourceGroups/io-p-rg-external/providers/Microsoft.Network/applicationGateways/io-p-appgateway"
+                  ]
+                },
+                "isOptional": true
+              },
+              {
+                "name": "PartId",
+                "isOptional": true
+              },
+              {
+                "name": "Version",
+                "value": "2.0",
+                "isOptional": true
+              },
+              {
+                "name": "TimeRange",
+                "value": "PT4H",
+                "isOptional": true
+              },
+              {
+                "name": "DashboardId",
+                "isOptional": true
+              },
+              {
+                "name": "DraftRequestParameters",
+                "value": {
+                  "scope": "hierarchy"
+                },
+                "isOptional": true
+              },
+              {
+                "name": "Query",
+                "value": "\nlet api_hosts = datatable (name: string) [\"app-backend.io.italia.it\"];\nlet threshold = 0.12;\nAzureDiagnostics\n| where originalHost_s in (api_hosts)\n| where requestUri_s matches regex \"basepath_override/api/v1/services/[^/]+\"\n| summarize\n  Total=count(),\n  Success=count(httpStatus_d < 500) by bin(TimeGenerated, 5m)\n| extend availability=toreal(Success) / Total\n| project TimeGenerated, availability, watermark=threshold\n| render timechart with (xtitle = \"time\", ytitle= \"availability(%)\")\n",
+                "isOptional": true
+              },
+              {
+                "name": "ControlType",
+                "value": "FrameControlChart",
+                "isOptional": true
+              },
+              {
+                "name": "SpecificChart",
+                "value": "Line",
+                "isOptional": true
+              },
+              {
+                "name": "PartTitle",
+                "value": "Availability (5m)",
+                "isOptional": true
+              },
+              {
+                "name": "PartSubTitle",
+                "value": "basepath_override/api/v1/services/{service_id}",
+                "isOptional": true
+              },
+              {
+                "name": "Dimensions",
+                "value": {
+                  "xAxis": {
+                    "name": "TimeGenerated",
+                    "type": "datetime"
+                  },
+                  "yAxis": [
+                    {
+                      "name": "availability",
+                      "type": "real"
+                    },
+                    {
+                      "name": "watermark",
+                      "type": "real"
+                    }
+                  ],
+                  "splitBy": [],
+                  "aggregation": "Sum"
+                },
+                "isOptional": true
+              },
+              {
+                "name": "LegendOptions",
+                "value": {
+                  "isEnabled": true,
+                  "position": "Bottom"
+                },
+                "isOptional": true
+              },
+              {
+                "name": "IsQueryContainTimeRange",
+                "value": false,
+                "isOptional": true
+              }
+            ],
+            "type": "Extension/Microsoft_OperationsManagementSuite_Workspace/PartType/LogsDashboardPart",
+            "settings": {
+              "content": {
+                "Query": "\nlet api_hosts = datatable (name: string) [\"app-backend.io.italia.it\"];\nlet threshold = 0.12;\nAzureDiagnostics\n| where originalHost_s in (api_hosts)\n| where requestUri_s matches regex \"basepath_override/api/v1/services/[^/]+\"\n| summarize\n  Total=count(),\n  Success=count(httpStatus_d < 500) by bin(TimeGenerated, 5m)\n| extend availability=toreal(Success) / Total\n| project TimeGenerated, availability, watermark=threshold\n| render timechart with (xtitle = \"time\", ytitle= \"availability(%)\")\n",
+                "PartTitle": "Availability (5m)"
+              }
+            }
+          }
+        },
+        "1": {
+          "position": {
+            "x": 6,
+            "y": 0,
+            "colSpan": 6,
+            "rowSpan": 4
+          },
+          "metadata": {
+            "inputs": [
+              {
+                "name": "resourceTypeMode",
+                "isOptional": true
+              },
+              {
+                "name": "ComponentId",
+                "isOptional": true
+              },
+              {
+                "name": "Scope",
+                "value": {
+                  "resourceIds": [
+                    "/subscriptions/uuid/resourceGroups/io-p-rg-external/providers/Microsoft.Network/applicationGateways/io-p-appgateway"
+                  ]
+                },
+                "isOptional": true
+              },
+              {
+                "name": "PartId",
+                "isOptional": true
+              },
+              {
+                "name": "Version",
+                "value": "2.0",
+                "isOptional": true
+              },
+              {
+                "name": "TimeRange",
+                "value": "PT4H",
+                "isOptional": true
+              },
+              {
+                "name": "DashboardId",
+                "isOptional": true
+              },
+              {
+                "name": "DraftRequestParameters",
+                "value": {
+                  "scope": "hierarchy"
+                },
+                "isOptional": true
+              },
+              {
+                "name": "Query",
+                "value": "\nlet api_url = \"basepath_override/api/v1/services/[^/]+\";\nlet api_hosts = datatable (name: string) [\"app-backend.io.italia.it\"];\nAzureDiagnostics\n| where originalHost_s in (api_hosts)\n| where requestUri_s matches regex api_url\n| extend HTTPStatus = case(\n  httpStatus_d between (100 .. 199), \"1XX\",\n  httpStatus_d between (200 .. 299), \"2XX\",\n  httpStatus_d between (300 .. 399), \"3XX\",\n  httpStatus_d between (400 .. 499), \"4XX\",\n  \"5XX\")\n| summarize count() by HTTPStatus, bin(TimeGenerated, 5m)\n| render areachart with (xtitle = \"time\", ytitle= \"count\")\n",
+                "isOptional": true
+              },
+              {
+                "name": "ControlType",
+                "value": "FrameControlChart",
+                "isOptional": true
+              },
+              {
+                "name": "SpecificChart",
+                "value": "Pie",
+                "isOptional": true
+              },
+              {
+                "name": "PartTitle",
+                "value": "Response Codes (5m)",
+                "isOptional": true
+              },
+              {
+                "name": "PartSubTitle",
+                "value": "basepath_override/api/v1/services/{service_id}",
+                "isOptional": true
+              },
+              {
+                "name": "Dimensions",
+                "value": {
+                  "xAxis": {
+                    "name": "httpStatus_d",
+                    "type": "string"
+                  },
+                  "yAxis": [
+                    {
+                      "name": "count_",
+                      "type": "long"
+                    }
+                  ],
+                  "splitBy": [],
+                  "aggregation": "Sum"
+                },
+                "isOptional": true
+              },
+              {
+                "name": "LegendOptions",
+                "value": {
+                  "isEnabled": true,
+                  "position": "Bottom"
+                },
+                "isOptional": true
+              },
+              {
+                "name": "IsQueryContainTimeRange",
+                "value": false,
+                "isOptional": true
+              }
+            ],
+            "type": "Extension/Microsoft_OperationsManagementSuite_Workspace/PartType/LogsDashboardPart",
+            "settings": {
+              "content": {
+                "Query": "\nlet api_url = \"basepath_override/api/v1/services/[^/]+\";\nlet api_hosts = datatable (name: string) [\"app-backend.io.italia.it\"];\nAzureDiagnostics\n| where originalHost_s in (api_hosts)\n| where requestUri_s matches regex api_url\n| extend HTTPStatus = case(\n  httpStatus_d between (100 .. 199), \"1XX\",\n  httpStatus_d between (200 .. 299), \"2XX\",\n  httpStatus_d between (300 .. 399), \"3XX\",\n  httpStatus_d between (400 .. 499), \"4XX\",\n  \"5XX\")\n| summarize count() by HTTPStatus, bin(TimeGenerated, 5m)\n| render areachart with (xtitle = \"time\", ytitle= \"count\")\n",
+                "SpecificChart": "StackedArea",
+                "PartTitle": "Response Codes (5m)",
+                "Dimensions": {
+                  "xAxis": {
+                    "name": "TimeGenerated",
+                    "type": "datetime"
+                  },
+                  "yAxis": [
+                    {
+                      "name": "count_",
+                      "type": "long"
+                    }
+                  ],
+                  "splitBy": [
+                    {
+                      "name": "HTTPStatus",
+                      "type": "string"
+                    }
+                  ],
+                  "aggregation": "Sum"
+                }
+              }
+            }
+          }
+        },
+        "2": {
+          "position": {
+            "x": 12,
+            "y": 0,
+            "colSpan": 6,
+            "rowSpan": 4
+          },
+          "metadata": {
+            "inputs": [
+              {
+                "name": "resourceTypeMode",
+                "isOptional": true
+              },
+              {
+                "name": "ComponentId",
+                "isOptional": true
+              },
+              {
+                "name": "Scope",
+                "value": {
+                  "resourceIds": [
+                    "/subscriptions/uuid/resourceGroups/io-p-rg-external/providers/Microsoft.Network/applicationGateways/io-p-appgateway"
+                  ]
+                },
+                "isOptional": true
+              },
+              {
+                "name": "PartId",
+                "isOptional": true
+              },
+              {
+                "name": "Version",
+                "value": "2.0",
+                "isOptional": true
+              },
+              {
+                "name": "TimeRange",
+                "value": "PT4H",
+                "isOptional": true
+              },
+              {
+                "name": "DashboardId",
+                "isOptional": true
+              },
+              {
+                "name": "DraftRequestParameters",
+                "value": {
+                  "scope": "hierarchy"
+                },
+                "isOptional": true
+              },
+              {
+                "name": "Query",
+                "value": "\nlet api_hosts = datatable (name: string) [\"app-backend.io.italia.it\"];\nlet threshold = 0.23;\nAzureDiagnostics\n| where originalHost_s in (api_hosts)\n| where requestUri_s matches regex \"basepath_override/api/v1/services/[^/]+\"\n| summarize\n    watermark=threshold,\n    duration_percentile_95=percentiles(timeTaken_d, 95) by bin(TimeGenerated, 5m)\n| render timechart with (xtitle = \"time\", ytitle= \"response time(s)\")\n",
+                "isOptional": true
+              },
+              {
+                "name": "ControlType",
+                "value": "FrameControlChart",
+                "isOptional": true
+              },
+              {
+                "name": "SpecificChart",
+                "value": "StackedColumn",
+                "isOptional": true
+              },
+              {
+                "name": "PartTitle",
+                "value": "Percentile Response Time (5m)",
+                "isOptional": true
+              },
+              {
+                "name": "PartSubTitle",
+                "value": "basepath_override/api/v1/services/{service_id}",
+                "isOptional": true
+              },
+              {
+                "name": "Dimensions",
+                "value": {
+                  "xAxis": {
+                    "name": "TimeGenerated",
+                    "type": "datetime"
+                  },
+                  "yAxis": [
+                    {
+                      "name": "duration_percentile_95",
+                      "type": "real"
+                    }
+                  ],
+                  "splitBy": [],
+                  "aggregation": "Sum"
+                },
+                "isOptional": true
+              },
+              {
+                "name": "LegendOptions",
+                "value": {
+                  "isEnabled": true,
+                  "position": "Bottom"
+                },
+                "isOptional": true
+              },
+              {
+                "name": "IsQueryContainTimeRange",
+                "value": false,
+                "isOptional": true
+              }
+            ],
+            "type": "Extension/Microsoft_OperationsManagementSuite_Workspace/PartType/LogsDashboardPart",
+            "settings": {
+              "content": {
+                "Query": "\nlet api_hosts = datatable (name: string) [\"app-backend.io.italia.it\"];\nlet threshold = 0.23;\nAzureDiagnostics\n| where originalHost_s in (api_hosts)\n| where requestUri_s matches regex \"basepath_override/api/v1/services/[^/]+\"\n| summarize\n    watermark=threshold,\n    duration_percentile_95=percentiles(timeTaken_d, 95) by bin(TimeGenerated, 5m)\n| render timechart with (xtitle = \"time\", ytitle= \"response time(s)\")\n",
+                "SpecificChart": "Line",
+                "PartTitle": "Percentile Response Time (5m)",
+                "Dimensions": {
+                  "xAxis": {
+                    "name": "TimeGenerated",
+                    "type": "datetime"
+                  },
+                  "yAxis": [
+                    {
+                      "name": "watermark",
+                      "type": "long"
+                    },
+                    {
+                      "name": "duration_percentile_95",
+                      "type": "real"
+                    }
+                  ],
+                  "splitBy": [],
+                  "aggregation": "Sum"
+                }
+              }
+            }
+          }
+        },
+        "3": {
+          "position": {
+            "x": 0,
+            "y": 4,
+            "colSpan": 6,
+            "rowSpan": 4
+          },
+          "metadata": {
+            "inputs": [
+              {
+                "name": "resourceTypeMode",
+                "isOptional": true
+              },
+              {
+                "name": "ComponentId",
+                "isOptional": true
+              },
+              {
+                "name": "Scope",
+                "value": {
+                  "resourceIds": [
+                    "/subscriptions/uuid/resourceGroups/io-p-rg-external/providers/Microsoft.Network/applicationGateways/io-p-appgateway"
+                  ]
+                },
+                "isOptional": true
+              },
+              {
+                "name": "PartId",
+                "isOptional": true
+              },
+              {
+                "name": "Version",
+                "value": "2.0",
+                "isOptional": true
+              },
+              {
+                "name": "TimeRange",
+                "value": "PT4H",
+                "isOptional": true
+              },
+              {
+                "name": "DashboardId",
+                "isOptional": true
+              },
+              {
+                "name": "DraftRequestParameters",
+                "value": {
+                  "scope": "hierarchy"
+                },
+                "isOptional": true
+              },
+              {
+                "name": "Query",
+                "value": "\nlet api_hosts = datatable (name: string) [\"app-backend.io.italia.it\"];\nlet threshold = 0.99;\nAzureDiagnostics\n| where originalHost_s in (api_hosts)\n| where requestUri_s matches regex \"basepath_override/api/v1/services\"\n| summarize\n  Total=count(),\n  Success=count(httpStatus_d < 500) by bin(TimeGenerated, 5m)\n| extend availability=toreal(Success) / Total\n| project TimeGenerated, availability, watermark=threshold\n| render timechart with (xtitle = \"time\", ytitle= \"availability(%)\")\n",
+                "isOptional": true
+              },
+              {
+                "name": "ControlType",
+                "value": "FrameControlChart",
+                "isOptional": true
+              },
+              {
+                "name": "SpecificChart",
+                "value": "Line",
+                "isOptional": true
+              },
+              {
+                "name": "PartTitle",
+                "value": "Availability (5m)",
+                "isOptional": true
+              },
+              {
+                "name": "PartSubTitle",
+                "value": "basepath_override/api/v1/services",
+                "isOptional": true
+              },
+              {
+                "name": "Dimensions",
+                "value": {
+                  "xAxis": {
+                    "name": "TimeGenerated",
+                    "type": "datetime"
+                  },
+                  "yAxis": [
+                    {
+                      "name": "availability",
+                      "type": "real"
+                    },
+                    {
+                      "name": "watermark",
+                      "type": "real"
+                    }
+                  ],
+                  "splitBy": [],
+                  "aggregation": "Sum"
+                },
+                "isOptional": true
+              },
+              {
+                "name": "LegendOptions",
+                "value": {
+                  "isEnabled": true,
+                  "position": "Bottom"
+                },
+                "isOptional": true
+              },
+              {
+                "name": "IsQueryContainTimeRange",
+                "value": false,
+                "isOptional": true
+              }
+            ],
+            "type": "Extension/Microsoft_OperationsManagementSuite_Workspace/PartType/LogsDashboardPart",
+            "settings": {
+              "content": {
+                "Query": "\nlet api_hosts = datatable (name: string) [\"app-backend.io.italia.it\"];\nlet threshold = 0.99;\nAzureDiagnostics\n| where originalHost_s in (api_hosts)\n| where requestUri_s matches regex \"basepath_override/api/v1/services\"\n| summarize\n  Total=count(),\n  Success=count(httpStatus_d < 500) by bin(TimeGenerated, 5m)\n| extend availability=toreal(Success) / Total\n| project TimeGenerated, availability, watermark=threshold\n| render timechart with (xtitle = \"time\", ytitle= \"availability(%)\")\n",
+                "PartTitle": "Availability (5m)"
+              }
+            }
+          }
+        },
+        "4": {
+          "position": {
+            "x": 6,
+            "y": 4,
+            "colSpan": 6,
+            "rowSpan": 4
+          },
+          "metadata": {
+            "inputs": [
+              {
+                "name": "resourceTypeMode",
+                "isOptional": true
+              },
+              {
+                "name": "ComponentId",
+                "isOptional": true
+              },
+              {
+                "name": "Scope",
+                "value": {
+                  "resourceIds": [
+                    "/subscriptions/uuid/resourceGroups/io-p-rg-external/providers/Microsoft.Network/applicationGateways/io-p-appgateway"
+                  ]
+                },
+                "isOptional": true
+              },
+              {
+                "name": "PartId",
+                "isOptional": true
+              },
+              {
+                "name": "Version",
+                "value": "2.0",
+                "isOptional": true
+              },
+              {
+                "name": "TimeRange",
+                "value": "PT4H",
+                "isOptional": true
+              },
+              {
+                "name": "DashboardId",
+                "isOptional": true
+              },
+              {
+                "name": "DraftRequestParameters",
+                "value": {
+                  "scope": "hierarchy"
+                },
+                "isOptional": true
+              },
+              {
+                "name": "Query",
+                "value": "\nlet api_url = \"basepath_override/api/v1/services\";\nlet api_hosts = datatable (name: string) [\"app-backend.io.italia.it\"];\nAzureDiagnostics\n| where originalHost_s in (api_hosts)\n| where requestUri_s matches regex api_url\n| extend HTTPStatus = case(\n  httpStatus_d between (100 .. 199), \"1XX\",\n  httpStatus_d between (200 .. 299), \"2XX\",\n  httpStatus_d between (300 .. 399), \"3XX\",\n  httpStatus_d between (400 .. 499), \"4XX\",\n  \"5XX\")\n| summarize count() by HTTPStatus, bin(TimeGenerated, 5m)\n| render areachart with (xtitle = \"time\", ytitle= \"count\")\n",
+                "isOptional": true
+              },
+              {
+                "name": "ControlType",
+                "value": "FrameControlChart",
+                "isOptional": true
+              },
+              {
+                "name": "SpecificChart",
+                "value": "Pie",
+                "isOptional": true
+              },
+              {
+                "name": "PartTitle",
+                "value": "Response Codes (5m)",
+                "isOptional": true
+              },
+              {
+                "name": "PartSubTitle",
+                "value": "basepath_override/api/v1/services",
+                "isOptional": true
+              },
+              {
+                "name": "Dimensions",
+                "value": {
+                  "xAxis": {
+                    "name": "httpStatus_d",
+                    "type": "string"
+                  },
+                  "yAxis": [
+                    {
+                      "name": "count_",
+                      "type": "long"
+                    }
+                  ],
+                  "splitBy": [],
+                  "aggregation": "Sum"
+                },
+                "isOptional": true
+              },
+              {
+                "name": "LegendOptions",
+                "value": {
+                  "isEnabled": true,
+                  "position": "Bottom"
+                },
+                "isOptional": true
+              },
+              {
+                "name": "IsQueryContainTimeRange",
+                "value": false,
+                "isOptional": true
+              }
+            ],
+            "type": "Extension/Microsoft_OperationsManagementSuite_Workspace/PartType/LogsDashboardPart",
+            "settings": {
+              "content": {
+                "Query": "\nlet api_url = \"basepath_override/api/v1/services\";\nlet api_hosts = datatable (name: string) [\"app-backend.io.italia.it\"];\nAzureDiagnostics\n| where originalHost_s in (api_hosts)\n| where requestUri_s matches regex api_url\n| extend HTTPStatus = case(\n  httpStatus_d between (100 .. 199), \"1XX\",\n  httpStatus_d between (200 .. 299), \"2XX\",\n  httpStatus_d between (300 .. 399), \"3XX\",\n  httpStatus_d between (400 .. 499), \"4XX\",\n  \"5XX\")\n| summarize count() by HTTPStatus, bin(TimeGenerated, 5m)\n| render areachart with (xtitle = \"time\", ytitle= \"count\")\n",
+                "SpecificChart": "StackedArea",
+                "PartTitle": "Response Codes (5m)",
+                "Dimensions": {
+                  "xAxis": {
+                    "name": "TimeGenerated",
+                    "type": "datetime"
+                  },
+                  "yAxis": [
+                    {
+                      "name": "count_",
+                      "type": "long"
+                    }
+                  ],
+                  "splitBy": [
+                    {
+                      "name": "HTTPStatus",
+                      "type": "string"
+                    }
+                  ],
+                  "aggregation": "Sum"
+                }
+              }
+            }
+          }
+        },
+        "5": {
+          "position": {
+            "x": 12,
+            "y": 4,
+            "colSpan": 6,
+            "rowSpan": 4
+          },
+          "metadata": {
+            "inputs": [
+              {
+                "name": "resourceTypeMode",
+                "isOptional": true
+              },
+              {
+                "name": "ComponentId",
+                "isOptional": true
+              },
+              {
+                "name": "Scope",
+                "value": {
+                  "resourceIds": [
+                    "/subscriptions/uuid/resourceGroups/io-p-rg-external/providers/Microsoft.Network/applicationGateways/io-p-appgateway"
+                  ]
+                },
+                "isOptional": true
+              },
+              {
+                "name": "PartId",
+                "isOptional": true
+              },
+              {
+                "name": "Version",
+                "value": "2.0",
+                "isOptional": true
+              },
+              {
+                "name": "TimeRange",
+                "value": "PT4H",
+                "isOptional": true
+              },
+              {
+                "name": "DashboardId",
+                "isOptional": true
+              },
+              {
+                "name": "DraftRequestParameters",
+                "value": {
+                  "scope": "hierarchy"
+                },
+                "isOptional": true
+              },
+              {
+                "name": "Query",
+                "value": "\nlet api_hosts = datatable (name: string) [\"app-backend.io.italia.it\"];\nlet threshold = 1;\nAzureDiagnostics\n| where originalHost_s in (api_hosts)\n| where requestUri_s matches regex \"basepath_override/api/v1/services\"\n| summarize\n    watermark=threshold,\n    duration_percentile_95=percentiles(timeTaken_d, 95) by bin(TimeGenerated, 5m)\n| render timechart with (xtitle = \"time\", ytitle= \"response time(s)\")\n",
+                "isOptional": true
+              },
+              {
+                "name": "ControlType",
+                "value": "FrameControlChart",
+                "isOptional": true
+              },
+              {
+                "name": "SpecificChart",
+                "value": "StackedColumn",
+                "isOptional": true
+              },
+              {
+                "name": "PartTitle",
+                "value": "Percentile Response Time (5m)",
+                "isOptional": true
+              },
+              {
+                "name": "PartSubTitle",
+                "value": "basepath_override/api/v1/services",
+                "isOptional": true
+              },
+              {
+                "name": "Dimensions",
+                "value": {
+                  "xAxis": {
+                    "name": "TimeGenerated",
+                    "type": "datetime"
+                  },
+                  "yAxis": [
+                    {
+                      "name": "duration_percentile_95",
+                      "type": "real"
+                    }
+                  ],
+                  "splitBy": [],
+                  "aggregation": "Sum"
+                },
+                "isOptional": true
+              },
+              {
+                "name": "LegendOptions",
+                "value": {
+                  "isEnabled": true,
+                  "position": "Bottom"
+                },
+                "isOptional": true
+              },
+              {
+                "name": "IsQueryContainTimeRange",
+                "value": false,
+                "isOptional": true
+              }
+            ],
+            "type": "Extension/Microsoft_OperationsManagementSuite_Workspace/PartType/LogsDashboardPart",
+            "settings": {
+              "content": {
+                "Query": "\nlet api_hosts = datatable (name: string) [\"app-backend.io.italia.it\"];\nlet threshold = 1;\nAzureDiagnostics\n| where originalHost_s in (api_hosts)\n| where requestUri_s matches regex \"basepath_override/api/v1/services\"\n| summarize\n    watermark=threshold,\n    duration_percentile_95=percentiles(timeTaken_d, 95) by bin(TimeGenerated, 5m)\n| render timechart with (xtitle = \"time\", ytitle= \"response time(s)\")\n",
+                "SpecificChart": "Line",
+                "PartTitle": "Percentile Response Time (5m)",
+                "Dimensions": {
+                  "xAxis": {
+                    "name": "TimeGenerated",
+                    "type": "datetime"
+                  },
+                  "yAxis": [
+                    {
+                      "name": "watermark",
+                      "type": "long"
+                    },
+                    {
+                      "name": "duration_percentile_95",
+                      "type": "real"
+                    }
+                  ],
+                  "splitBy": [],
+                  "aggregation": "Sum"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "metadata": {
+    "model": {
+      "timeRange": {
+        "value": {
+          "relative": {
+            "duration": 24,
+            "timeUnit": 1
+          }
+        },
+        "type": "MsPortalFx.Composition.Configuration.ValueTypes.TimeRange"
+      },
+      "filterLocale": {
+        "value": "en-us"
+      },
+      "filters": {
+        "value": {
+          "MsPortalFx_TimeRange": {
+            "model": {
+              "format": "local",
+              "granularity": "auto",
+              "relative": "48h"
+            },
+            "displayCache": {
+              "name": "Local Time",
+              "value": "Past 48 hours"
+            },
+            "filteredPartIds": [
+              "StartboardPart-LogsDashboardPart-9badbd78-7607-4131-8fa1-8b85191432ed",
+              "StartboardPart-LogsDashboardPart-9badbd78-7607-4131-8fa1-8b85191432ef",
+              "StartboardPart-LogsDashboardPart-9badbd78-7607-4131-8fa1-8b85191432f1",
+              "StartboardPart-LogsDashboardPart-9badbd78-7607-4131-8fa1-8b85191432f3",
+              "StartboardPart-LogsDashboardPart-9badbd78-7607-4131-8fa1-8b85191432f5",
+              "StartboardPart-LogsDashboardPart-9badbd78-7607-4131-8fa1-8b85191432f7",
+              "StartboardPart-LogsDashboardPart-9badbd78-7607-4131-8fa1-8b85191432f9",
+              "StartboardPart-LogsDashboardPart-9badbd78-7607-4131-8fa1-8b85191432fb",
+              "StartboardPart-LogsDashboardPart-9badbd78-7607-4131-8fa1-8b85191432fd"
+            ]
+          }
+        }
+      }
+    }
+  }
+}
+  PROPS
+
+  tags = var.tags
+}
+
+
+resource "azurerm_monitor_scheduled_query_rules_alert" "alarm_availability_0" {
+  name                = replace(join("_",split("/", "${local.name}-availability @ basepath_override/api/v1/services/{service_id}")), "/\\{|\\}/", "")
+  resource_group_name = data.azurerm_resource_group.this.name
+  location            = data.azurerm_resource_group.this.location
+
+  action {
+    action_group = ["/subscriptions/uuid/resourceGroups/my-rg/providers/microsoft.insights/actionGroups/my-action-group-email", "/subscriptions/uuid/resourceGroups/my-rg/providers/microsoft.insights/actionGroups/my-action-group-slack"]
+  }
+
+  data_source_id          = "data_source_id"
+  description             = "Availability for basepath_override/api/v1/services/{service_id} is less than or equal to 99% - ${local.dashboard_base_addr}${azurerm_portal_dashboard.this.id}"
+  enabled                 = true
+  auto_mitigation_enabled = false
+
+  query = <<-QUERY
+
+    
+let api_hosts = datatable (name: string) ["app-backend.io.italia.it"];
+let threshold = 0.12;
+AzureDiagnostics
+| where originalHost_s in (api_hosts)
+| where requestUri_s matches regex "basepath_override/api/v1/services/[^/]+"
+| summarize
+  Total=count(),
+  Success=count(httpStatus_d < 500) by bin(TimeGenerated, 5m)
+| extend availability=toreal(Success) / Total
+| where availability < threshold
+
+
+  QUERY
+
+  severity    = 1
+  frequency   = 111
+  time_window = 222
+  trigger {
+    operator  = "GreaterThanOrEqual"
+    threshold = 333
+  }
+
+  tags = var.tags
+}
+
+resource "azurerm_monitor_scheduled_query_rules_alert" "alarm_time_0" {
+  name                = replace(join("_",split("/", "${local.name}-responsetime @ basepath_override/api/v1/services/{service_id}")), "/\\{|\\}/", "")
+  resource_group_name = data.azurerm_resource_group.this.name
+  location            = data.azurerm_resource_group.this.location
+
+  action {
+    action_group = ["/subscriptions/uuid/resourceGroups/my-rg/providers/microsoft.insights/actionGroups/my-action-group-email", "/subscriptions/uuid/resourceGroups/my-rg/providers/microsoft.insights/actionGroups/my-action-group-slack"]
+  }
+
+  data_source_id          = "data_source_id"
+  description             = "Response time for basepath_override/api/v1/services/{service_id} is less than or equal to 1s - ${local.dashboard_base_addr}${azurerm_portal_dashboard.this.id}"
+  enabled                 = true
+  auto_mitigation_enabled = false
+
+  query = <<-QUERY
+
+    
+let api_hosts = datatable (name: string) ["app-backend.io.italia.it"];
+let threshold = 0.23;
+AzureDiagnostics
+| where originalHost_s in (api_hosts)
+| where requestUri_s matches regex "basepath_override/api/v1/services/[^/]+"
+| summarize
+    watermark=threshold,
+    duration_percentile_95=percentiles(timeTaken_d, 95) by bin(TimeGenerated, 5m)
+| where duration_percentile_95 > threshold
+
+
+  QUERY
+
+  severity    = 1
+  frequency   = 444
+  time_window = 555
+  trigger {
+    operator  = "GreaterThanOrEqual"
+    threshold = 666
+  }
+
+  tags = var.tags
+}
+
+resource "azurerm_monitor_scheduled_query_rules_alert" "alarm_availability_1" {
+  name                = replace(join("_",split("/", "${local.name}-availability @ basepath_override/api/v1/services")), "/\\{|\\}/", "")
+  resource_group_name = data.azurerm_resource_group.this.name
+  location            = data.azurerm_resource_group.this.location
+
+  action {
+    action_group = ["/subscriptions/uuid/resourceGroups/my-rg/providers/microsoft.insights/actionGroups/my-action-group-email", "/subscriptions/uuid/resourceGroups/my-rg/providers/microsoft.insights/actionGroups/my-action-group-slack"]
+  }
+
+  data_source_id          = "data_source_id"
+  description             = "Availability for basepath_override/api/v1/services is less than or equal to 99% - ${local.dashboard_base_addr}${azurerm_portal_dashboard.this.id}"
+  enabled                 = true
+  auto_mitigation_enabled = false
+
+  query = <<-QUERY
+
+    
+let api_hosts = datatable (name: string) ["app-backend.io.italia.it"];
+let threshold = 0.99;
+AzureDiagnostics
+| where originalHost_s in (api_hosts)
+| where requestUri_s matches regex "basepath_override/api/v1/services"
+| summarize
+  Total=count(),
+  Success=count(httpStatus_d < 500) by bin(TimeGenerated, 5m)
+| extend availability=toreal(Success) / Total
+| where availability < threshold
+
+
+  QUERY
+
+  severity    = 1
+  frequency   = 10
+  time_window = 20
+  trigger {
+    operator  = "GreaterThanOrEqual"
+    threshold = 2
+  }
+
+  tags = var.tags
+}
+
+resource "azurerm_monitor_scheduled_query_rules_alert" "alarm_time_1" {
+  name                = replace(join("_",split("/", "${local.name}-responsetime @ basepath_override/api/v1/services")), "/\\{|\\}/", "")
+  resource_group_name = data.azurerm_resource_group.this.name
+  location            = data.azurerm_resource_group.this.location
+
+  action {
+    action_group = ["/subscriptions/uuid/resourceGroups/my-rg/providers/microsoft.insights/actionGroups/my-action-group-email", "/subscriptions/uuid/resourceGroups/my-rg/providers/microsoft.insights/actionGroups/my-action-group-slack"]
+  }
+
+  data_source_id          = "data_source_id"
+  description             = "Response time for basepath_override/api/v1/services is less than or equal to 1s - ${local.dashboard_base_addr}${azurerm_portal_dashboard.this.id}"
+  enabled                 = true
+  auto_mitigation_enabled = false
+
+  query = <<-QUERY
+
+    
+let api_hosts = datatable (name: string) ["app-backend.io.italia.it"];
+let threshold = 1;
+AzureDiagnostics
+| where originalHost_s in (api_hosts)
+| where requestUri_s matches regex "basepath_override/api/v1/services"
+| summarize
+    watermark=threshold,
+    duration_percentile_95=percentiles(timeTaken_d, 95) by bin(TimeGenerated, 5m)
+| where duration_percentile_95 > threshold
+
+
+  QUERY
+
+  severity    = 1
+  frequency   = 10
+  time_window = 20
+  trigger {
+    operator  = "GreaterThanOrEqual"
+    threshold = 2
+  }
+
+  tags = var.tags
+}
+

--- a/test/test_builder_azure_dashboard.py
+++ b/test/test_builder_azure_dashboard.py
@@ -88,3 +88,42 @@ def test_produce_the_template_with_overrides(snapshot):
 
     snapshot.snapshot_dir = 'test/snapshots'  # This line is optional.
     snapshot.assert_match(prova, 'iobackend_light_overrides.txt')
+
+
+def test_produce_the_template_with_overrided_base_path(snapshot):
+    """
+    GIVEN a valid list of parameter
+    WHEN overrides are defined for and endpoint
+    THEN the template is rendered and override properties applied
+    """
+    resolver = OA3Resolver(f"{DATA_BASE_PATH}/io_backend_light.yaml")
+    builder = create_builder(
+        "azure-dashboard",
+        resolver=resolver,
+        name=NAME,
+        resource_type=RESOURCE_TYPE,
+        location=LOCATION,
+        timespan=TIMESPAN,
+        evaluation_frequency=EVALUATION_FREQUENCY,
+        evaluation_time_window=EVALUATION_TIME_WINDOW,
+        event_occurrences=EVENT_OCCURRENCES,
+        resources=[RESOURCE_ID],
+        data_source_id=DATA_SOURCE_ID,
+        action_groups_ids=ACTION_GROUPS_IDS
+    )
+
+    overrides = {"endpoints": {"/api/v1/services/{service_id}": {"availability_threshold": 0.12,
+                                                                 "availability_evaluation_frequency": 111,
+                                                                 "availability_evaluation_time_window": 222,
+                                                                 "availability_event_occurrences": 333,
+                                                                 "response_time_threshold": 0.23,
+                                                                 "response_time_evaluation_frequency": 444,
+                                                                 "response_time_evaluation_time_window": 555,
+                                                                 "response_time_event_occurrences": 666,
+                                                                 }},
+                 "base_path": "basepath_override"
+                                                                 }
+    prova = builder.produce(overrides)
+
+    snapshot.snapshot_dir = 'test/snapshots'  # This line is optional.
+    snapshot.assert_match(prova, 'iobackend_light_overrides_base_path.txt')

--- a/test/test_builder_azure_dashboard.py
+++ b/test/test_builder_azure_dashboard.py
@@ -122,7 +122,7 @@ def test_produce_the_template_with_overrided_base_path(snapshot):
                                                                  "response_time_event_occurrences": 666,
                                                                  }},
                  "base_path": "basepath_override"
-                                                                 }
+                 }
     prova = builder.produce(overrides)
 
     snapshot.snapshot_dir = 'test/snapshots'  # This line is optional.


### PR DESCRIPTION
GHA for lint and tests seems to be broken. This [PR](https://github.com/pagopa/opex-dashboard/pull/48) aims to fix those actions
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
<!--- Describe your changes in detail -->
Add `base_path` optional template variable that can be overridden (default value blank string) used to build queries paths.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This variable can be used to customize alerts and dashboards queries paths adding a customizable base path to the openapi api's ones
#### Update dependency

Remmeber to update also the package version here https://github.com/pagopa/opex-dashboard-azure-action/blob/main/Dockerfile

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Unit test + local template generation test
#### Screenshots (if appropriate):

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Chore (nothing changes by a user perspective)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
